### PR TITLE
Allow crafting of Amulet of Agile Fists

### DIFF
--- a/CraftMagicItems/Main.cs
+++ b/CraftMagicItems/Main.cs
@@ -81,6 +81,7 @@ namespace CraftMagicItems {
         private const int MasterworkCost = 300;
         private const int WeaponPlusCost = 2000;
         private const int ArmourPlusCost = 1000;
+        private const int UnarmedPlusCost = 4000;
         private const string BondedItemRitual = "bondedItemRitual";
 
         private static readonly string[] CraftingPriceStrings = {
@@ -1227,7 +1228,8 @@ namespace CraftMagicItems {
                 if (IsItemLegalEnchantmentLevel(itemToCraft)) {
                     RenderRecipeBasedCraftItemControl(caster, craftingData, selectedRecipe, casterLevel, itemToCraft, upgradeItem);
                 } else {
-                    RenderLabel($"This would result in {itemToCraft.Name} having an equivalent enhancement bonus of more than +10");
+                    var maxEnchantmentLevel = ItemMaxEnchantmentLevel(itemToCraft);
+                    RenderLabel($"This would result in {itemToCraft.Name} having an equivalent enhancement bonus of more than +{maxEnchantmentLevel}");
                 }
             }
         }
@@ -2364,6 +2366,13 @@ namespace CraftMagicItems {
 
             return 0;
         }
+        private static int ItemMaxEnchantmentLevel(BlueprintItem blueprint) {
+            if (blueprint is BlueprintItemWeapon || blueprint is BlueprintItemArmor || blueprint is BlueprintItemShield) {
+                return 10;
+            } else {
+                return 5;
+            }
+        }
 
         private static int ItemPlusEquivalent(BlueprintItem blueprint) {
             if (blueprint == null || blueprint.Enchantments == null) {
@@ -2402,8 +2411,7 @@ namespace CraftMagicItems {
                 return IsItemLegalEnchantmentLevel(shield.ArmorComponent) && IsItemLegalEnchantmentLevel(shield.WeaponComponent);
             }
 
-            var plusEquivalent = ItemPlusEquivalent(blueprint);
-            return plusEquivalent <= 10;
+            return ItemPlusEquivalent(blueprint) <= ItemMaxEnchantmentLevel(blueprint);
         }
 
         private static int GetEnchantmentCost(string enchantmentId, BlueprintItem blueprint) {
@@ -2489,6 +2497,15 @@ namespace CraftMagicItems {
                     return cost + RulesRecipeItemCost(doubleWeapon.SecondWeapon);
                 }
                 return cost;
+            }
+
+            if (ItemPlusEquivalent(blueprint) > 0) {
+                var enhancementLevel = ItemPlusEquivalent(blueprint);
+                var enhancementCost = enhancementLevel * enhancementLevel * UnarmedPlusCost;
+                cost += enhancementCost;
+                if (mostExpensiveEnchantmentCost < enhancementCost) {
+                    mostExpensiveEnchantmentCost = enhancementCost;
+                }
             }
 
             // Usable (belt slot) items cost double.

--- a/Data/WondrousRecipes.json
+++ b/Data/WondrousRecipes.json
@@ -36,7 +36,7 @@
   },
   {
     "Name": "UnarmedAttacks",
-    "NameId": "craftMagicItems-recipeType-unarmed",
+    "NameId": "craftMagicItems-recipeType-unarmed-attacks",
     "BonusTypeId": "696d7c0e-f960-4b92-a703-01d8ff9c0674",
     "Enchantments": [
       "da7d830b3f75749458c2e51524805560",
@@ -48,8 +48,23 @@
     "CasterLevelStart": 3,
     "CasterLevelMultiplier": 3,
     "PrerequisiteSpells": ["f1100650705a69c4384d3edd88ba0f52"],
-    "CostType": "LevelSquared",
-    "CostFactor": 4000
+    "CostType": "EnhancementLevelSquared",
+    "CostFactor": 1,
+    "OnlyForSlots": ["Neck"]
+  },
+  {
+    "Name": "UnarmedAgile",
+    "NameId": "craftMagicItems-recipeType-unarmed-agile",
+    "BonusTypeId": "696d7c0e-f960-4b92-a703-01d8ff9c0674",
+    "Enchantments": [
+      "90316f5801dbe4748a66816a7c00380c"
+    ],
+    "CasterLevelStart": 7,
+    "CasterLevelMultiplier": 0,
+    "PrerequisiteSpells": ["de7a025d48ad5da4991e7d3c682cf69d"],
+    "CostType": "EnhancementLevelSquared",
+    "CostFactor": 1,
+    "OnlyForSlots": ["Neck"]
   },
   {
     "Name": "FeatherStep",

--- a/L10n/Strings_enGB.json
+++ b/L10n/Strings_enGB.json
@@ -64,8 +64,12 @@
     "Value": "Arms and Armor"
   },
   {
-    "Key": "craftMagicItems-recipeType-unarmed",
-    "Value": "Unarmed Attacks"
+    "Key": "craftMagicItems-recipeType-unarmed-attacks",
+    "Value": "Mighty Fists"
+  },
+  {
+    "Key": "craftMagicItems-recipeType-unarmed-agile",
+    "Value": "Agile"
   },
   {
     "Key": "craftMagicItems-timer-buff-name",

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ For details, see the mod page here: https://www.nexusmods.com/pathfinderkingmake
 * Dragonhide is called "dragonscale".  Ironwood?
 * Request for https://www.d20pfsrd.com/magic-items/wondrous-items/m-p/page-of-spell-knowledge/
 
-* Mighty Fists enchantment is stacking - looks like a bug in Owlcat's code
+* Mighty Fists enchantment is stacking - looks like a bug in Owlcat's code (require Mighty Fists to only be on Amulet)
 * Tabletop Amulet of Mighty Fists actually allows all relevant weapon enhancements (such as Flaming or Agile)... not
-        sure if the engine can even do that. 
+        sure if the engine can even do that. (Added Agile. Seems to be the only supported enhancement)
 * Mundane crafting - craft shields with shield spikes?  Tricky, the base spiked shield blueprints are weapons...
 * Craft Rod?
 * In-game GUI


### PR DESCRIPTION
Add support for EnhancementLevelSquared to wondrous items (used for existing attack (mighty fists) and new agile enhancement).
Require agile/might fists to only be on neck.